### PR TITLE
Add await to bot.handler.propagate(message)

### DIFF
--- a/docs/modules/examples.rst
+++ b/docs/modules/examples.rst
@@ -24,7 +24,7 @@ Super duper basic bot
 
     @bot.event
     async def on_message(message):
-        bot.handler.propagate(message)
+        await bot.handler.propagate(message)
         await bot.process_commands(message)
 
 

--- a/docs/modules/examples.rst
+++ b/docs/modules/examples.rst
@@ -51,7 +51,7 @@ How to use templating in a string
 
     @bot.event
     async def on_message(message):
-        bot.handler.propagate(message)
+        await bot.handler.propagate(message)
         await bot.process_commands(message)
 
     if __name__ == "__main__":
@@ -91,7 +91,7 @@ How to use templating in embeds
 
     @bot.event
     async def on_message(message):
-        bot.handler.propagate(message)
+        await bot.handler.propagate(message)
         await bot.process_commands(message)
 
     if __name__ == "__main__":


### PR DESCRIPTION
# Description

bot.handler.propagate(message) was not awaited in the example in line 27 and does not work without it

